### PR TITLE
Skeleton implementation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,7 @@ inc/
 /MANIFEST.bak
 /pm_to_blib
 /*.zip
+
+
+# Data
+commitm.d/descriptions/

--- a/commitm
+++ b/commitm
@@ -4,6 +4,7 @@ use v5.10;
 use utf8;
 use strict;
 use FindBin qw($Bin $Script);
+use lib "$Bin/lib";
 use YAML::XS qw(LoadFile DumpFile);
 use Getopt::Long;
 use Try::Catch;
@@ -13,6 +14,8 @@ use List::Util qw(first);
 use List::MoreUtils qw(uniq);
 use Regexp::Common qw(profanity);
 use Pod::Usage qw(pod2usage);
+
+use DescriptiveMessageGenerator;
 
 fun get_message_filename($lang = undef) {
     state $filename = "$Bin/$Script.d/" . ($lang ? "lang/$lang" : 'messages') .
@@ -95,14 +98,17 @@ fun add_message($lang = undef, $message = undef) {
 fun main() {
     my $lang;
     my $help = 0;
+    my $descriptive = 0;
     my $added_message = '';
     my $search_str = '';
+
     try {
         GetOptions(
             'help' => \$help,
             'language=s' => \$lang,
             'add=s' => \$added_message,
             'grep=s' => \$search_str,
+            'descriptive' => \$descriptive
         ) or pod2usage(1);
     }
     catch {
@@ -125,6 +131,7 @@ fun main() {
     }
     else {
         output_message($lang, $search_str);
+        say "\n" . DescriptiveMessageGenerator::get_message() if $descriptive;        
     }
 }
 

--- a/lib/DescriptiveMessageGenerator.pm
+++ b/lib/DescriptiveMessageGenerator.pm
@@ -1,0 +1,14 @@
+package DescriptiveMessageGenerator;
+
+use 5.20.0;
+use warnings;
+
+use Function::Parameters;
+
+
+fun get_message() {
+    return "Foobar";
+}
+
+
+1;

--- a/tools/clean-file.pl
+++ b/tools/clean-file.pl
@@ -1,0 +1,95 @@
+use 5.20.0;
+use warnings;
+
+use Encode qw( encode_utf8 );
+use FindBin qw( $Bin $Script );
+use lib "$Bin/lib";
+
+my $SKIP_INITIAL_LINES = 300;
+my $MAX_LINES = $SKIP_INITIAL_LINES + 1100;
+
+
+my $file_path = $ARGV[0];
+
+die "No file path supplied!" unless $file_path;
+
+clean($file_path);
+
+
+
+sub clean {
+    my ($file_path) = @_;
+
+    # Trim out leading and trailing spaces
+    # Exclude empty lines
+    # Skip first 100 lines, usually just metadata
+
+    open(my $fh, '<:encoding(UTF-8)', $file_path)
+        or die "Could not open file '$file_path': $!";
+
+    my $skip = 0;
+    my $max_lines = 0;
+
+    my @lines;
+
+    while (my $line = <$fh>) {
+        next if $skip++ < $SKIP_INITIAL_LINES; # Usually just metadata
+        last if $max_lines++ == $MAX_LINES;    # Limit sizes 
+
+        $line = trim($line);
+        $line = remove_footnote_markers($line);
+
+        next if (!$line || $line eq '');       # Trash empty lines
+
+        # With Gutenberg text files, especially plays, a line marker
+        # is significant to differentiate sentences.
+        push @lines, $line . "\n";
+    }
+
+    # Instead of working with lines, we wish to work with sentences.
+    # A simple heuristic is to use common punctuation marks as sentence
+    # separators.
+    my $sentences_text = to_sentences(\@lines);
+    print encode_utf8($sentences_text);
+}
+
+sub trim {
+    my ($s) = @_;
+
+    # Remove trailing and leading whitespace
+    $s =~ s/^\s+|\s+$//g;
+
+    # Remove more than 1 consecutive whitespace with a single space
+    $s =~ s/\s\s//g;
+
+    return $s;
+}
+
+sub remove_footnote_markers {
+    my ($s) = @_;
+
+    # '[12]' -> ''
+    $s =~ s/\[[0-9]+\]//g;
+
+    return $s;
+}
+
+sub to_sentences {
+    my ($lines_ref) = @_;
+
+    my $text = join('', @{$lines_ref});
+
+    # We wish to retain punctuation marks after splitting, capture groups
+    # add an extra field, but no clue how to use it in the result, it just
+    # dumps it out as a split item
+    # So we split in distinct steps, one for each punctuation mark.
+    my $marker = '<cleanfile.pl>';
+    my $sentences = join($marker, split(/\. /, $text . "."));
+    $sentences = join($marker, split(/\? /, $sentences . "?"));
+    $sentences = join($marker, split(/\! /, $sentences . "!"));
+
+    # Finally, we split into lines
+    $sentences = join("\n", split(/$marker/, $sentences));
+
+    return $sentences;
+}

--- a/tools/clean-file.pl
+++ b/tools/clean-file.pl
@@ -20,10 +20,6 @@ clean($file_path);
 sub clean {
     my ($file_path) = @_;
 
-    # Trim out leading and trailing spaces
-    # Exclude empty lines
-    # Skip first 100 lines, usually just metadata
-
     open(my $fh, '<:encoding(UTF-8)', $file_path)
         or die "Could not open file '$file_path': $!";
 
@@ -37,9 +33,10 @@ sub clean {
         last if $max_lines++ == $MAX_LINES;    # Limit sizes 
 
         $line = trim($line);
-        $line = remove_footnote_markers($line);
 
         next if (!$line || $line eq '');       # Trash empty lines
+
+        $line = remove_footnote_markers($line);
 
         # With Gutenberg text files, especially plays, a line marker
         # is significant to differentiate sentences.

--- a/tools/get-files.sh
+++ b/tools/get-files.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/zsh
 
 DATA_DIR=commitm.d/descriptions
 

--- a/tools/get-files.sh
+++ b/tools/get-files.sh
@@ -1,5 +1,9 @@
 #!/bin/zsh
 
+#
+# To be run from within the top-level 'commitm' checkout directory.
+#
+
 DATA_DIR=commitm.d/descriptions
 
 mkdir -p $DATA_DIR
@@ -7,12 +11,20 @@ mkdir -p $DATA_DIR
 get_text() {
     url="$1"
     local_name="$DATA_DIR/$2"
+    local_cleaned_name="$local_name.clean"
 
     if [ ! -f "$local_name" ]; then
         echo "Fetching[$url] -> [$local_name]"
         curl "$url" > "$local_name"
     else
         echo "File [$local_name] exists, skipping fetch"
+    fi
+
+    if [ ! -f "$local_cleaned_name" ]; then
+        echo "Normalising/cleaning[$local_name] -> [$local_cleaned_name]"
+        perl tools/clean-file.pl "$local_name" > $local_cleaned_name
+    else
+        echo "File [$local_cleaned_name] exists, skipping clean"
     fi
 }
 

--- a/tools/get-files.sh
+++ b/tools/get-files.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+DATA_DIR=commitm.d/descriptions
+
+mkdir -p $DATA_DIR
+
+get_text() {
+    url="$1"
+    local_name="$DATA_DIR/$2"
+
+    if [ ! -f "$local_name" ]; then
+        echo "Fetching[$url] -> [$local_name]"
+        curl "$url" > "$local_name"
+    else
+        echo "File [$local_name] exists, skipping fetch"
+    fi
+}
+
+get_text "https://www.gutenberg.org/files/1514/1514-0.txt" midsummers-night-dream.txt
+get_text "https://www.gutenberg.org/files/27761/27761-0.txt" hamlet.txt


### PR DESCRIPTION
Just an overall (working) skeleton structure (ala `get_font_size() { return 12 }`) to have longer description sections in the commit message, feel free to move it into a branch first, while we reason things out.

* New `--descriptive` switch: it's optional. I think the main use case is still one-liners, so happy with not adding this stuff unless the switch is specified.
* Added a `tools/get-files.sh`, to download the gutenberg sample files. Given the main use case, don't really want to commit data files to the repository. This adds a download step, and requires `curl` and `bash`, but a good start for the moment. Could be better named, too. 
* Since the logic will be a bit more involved, I did not want to clutter the main script, so added a new `lib` dir + module.

To test:

```
./commitm --descriptive
```

Returns dummy message, downloaded files not in use yet.
